### PR TITLE
Disable asserts in libnice

### DIFF
--- a/recipes/libnice.recipe
+++ b/recipes/libnice.recipe
@@ -13,7 +13,8 @@ class Recipe(recipe.Recipe):
     meson_options = {'tests' : 'disabled',
                      'gupnp' : 'disabled',
                      'gstreamer' : 'enabled',
-                     'crypto-library' : 'openssl'}
+                     'crypto-library' : 'openssl',
+                     'c_args': '-DG_DISABLE_ASSERT'}
     deps = ['glib', 'gstreamer-1.0']
 
     patches = ['libnice/0001-Remove-Gslice-without-breaking-anything.patch']


### PR DESCRIPTION
Sets the `G_DISABLE_ASSERT` macro in libnice so that asserts don't exit the application.

CN build is available [here](https://github.com/blinemedical/capture-node/actions/runs/9351873056).