### PR TITLE
[VIDEO-2912] Add assert and checks variants

### DIFF
--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -200,21 +200,31 @@ runs:
         echo "CERBERO_ARGS=${CERBERO_ARGS}" >> $GITHUB_ENV
         echo "CERBERO_PACKAGE_ARGS=${CERBERO_PACKAGE_ARGS}" >> $GITHUB_ENV
 
-    - id: restore-cerbero-cache
+        config_hash=$(echo "${CERBERO_ARGS}${{ inputs.config }}" | sha256sum | cut -d' ' -f1)
+        echo "config-hash=${config_hash}" >> $GITHUB_OUTPUT
+
+    - id: restore-cerbero-sources-cache
       if: ${{ steps.variables.outputs.do-build }}
       uses: actions/cache/restore@v4
       with:
-        path: |
-          ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
-          ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
         key: |
-          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ runner.name }}
+          cerbero-sources-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}
         restore-keys: |
-          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-
-          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-
-          ${{ runner.os }}-cerbero-bootstrap-
+          cerbero-sources-${{ steps.version-info.outputs.gstreamer-version }}-
+          cerbero-sources-
 
-    - if: ${{ steps.variables.outputs.do-build && steps.restore-cerbero-cache.outputs.cache-matched-key }}
+    - id: restore-cerbero-deps-cache
+      if: ${{ steps.variables.outputs.do-build }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+        key: |
+          ${{ runner.os }}-cerbero-deps-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-${{ runner.name }}
+        restore-keys: |
+          ${{ runner.os }}-cerbero-deps-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ steps.cerbero-config.outputs.config-hash }}-
+
+    - if: ${{ steps.variables.outputs.do-build && steps.restore-cerbero-deps-cache.outputs.cache-matched-key }}
       shell: msys2 -eo pipefail {0}
       run: |
         # Restore Cerbero dependencies
@@ -266,14 +276,17 @@ runs:
         group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
         group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
 
-    - id: cache-cerbero-bootstrap
-      if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-cache.outputs.cache-hit }}
+    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-sources-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
-        path: |
-          ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
-          ${{ steps.cerbero-config.outputs.cerbero-sources }}
-        key: ${{ steps.restore-cerbero-cache.outputs.cache-primary-key }}
+        path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        key: ${{ steps.restore-cerbero-deps-cache.cache-primary-key }}
+
+    - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+        key: ${{ steps.restore-cerbero-deps-cache.cache-primary-key }}
 
     - id: build-packages
       if: ${{ steps.variables.outputs.do-build }}

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -1,0 +1,340 @@
+name: Build GStreamer with Cerbero on Windows
+description: Uses the GStreamer Cerbero build aggregator to build GStreamer MSI packages on the local toolchain
+inputs:
+  cerbero-repo:
+    description: 'Repository to use for Cerbero'
+    required: false
+    default: $GITHUB_ACTION_REPOSITORY
+  cerbero-ref:
+    description: 'Ref to use for Cerbero'
+    required: true
+  config:
+    description: 'Name of the configuration file to use'
+    required: false
+    default: 'win64.cbc'
+  cerbero-args:
+    description: 'Additional args to pass to Cerbero'
+    required: false
+    default: '--clocktime --timestamps -v visualstudio'
+  cerbero-package-args:
+    description: 'Additional args to pass to Cerbero package'
+    required: false
+    default: ''
+  bootstrap-system:
+    description: 'Whether to bootstrap the system'
+    required: false
+    default: 'false'
+  s3-download-paths:
+    description: 'S3 paths to download from'
+    required: false
+  s3-upload-path:
+    description: 'S3 path to upload to'
+    required: false
+  force:
+    description: 'Whether to force the build'
+    required: false
+  cleanup:
+    description: 'Whether to clean the Cerbero build directory'
+    required: false
+    default: 'true'
+outputs:
+  gstreamer-version:
+    description: 'GStreamer version'
+    value: ${{ steps.version-info.outputs.gstreamer-version }}
+  cerbero-short-sha:
+    description: 'Short SHA of the Cerbero checkout'
+    value: ${{ steps.version-info.outputs.cerbero-short-sha }}
+  cerbero-path:
+    description: 'Path to the Cerbero checkout'
+    value: ${{ inputs.cleanup != 'true' && 'cerbero' }}
+  runtime-installer-path:
+    description: 'Location of the GStreamer runtime installer'
+    value: ${{ steps.build-packages.outputs.runtime-msi }}
+  runtime-installer-url:
+    description: 'Presigned S3 URL of the GStreamer runtime installer if s3-upload-path is set'
+    value: ${{ steps.presign-urls.outputs.runtime-url }}
+  devel-installer-path:
+    description: 'Location of the GStreamer development installer'
+    value: ${{ steps.build-packages.outputs.dev-msi }}
+  devel-installer-url:
+    description: 'Presigned S3 URL of the GStreamer development installer if s3-upload-path is set'
+    value: ${{ steps.presign-urls.outputs.dev-url }}
+runs:
+  using: "composite"
+  steps:
+
+    - id: setup-msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: UCRT64
+        path-type: inherit
+        release: false
+        install: >-
+          mingw-w64-ucrt-x86_64-jq
+          m4
+          mingw-w64-ucrt-x86_64-gcc-libs
+          mingw-w64-ucrt-x86_64-libwinpthread-git
+          bison
+          mingw-w64-ucrt-x86_64-diffutils
+          flex
+          mingw-w64-ucrt-x86_64-gperf
+          mingw-w64-ucrt-x86_64-make
+          mingw-w64-ucrt-x86_64-ninja
+          mingw-w64-ucrt-x86_64-perl
+
+    - shell: msys2 -eo pipefail {0}
+      run: git config --global core.autocrlf false
+
+    - id: get-cerbero
+      name: Get Cerbero
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.cerbero-repo }}
+        path: cerbero
+        ref: ${{ inputs.cerbero-ref }}
+
+    - id: version-info
+      shell: msys2 -eo pipefail {0}
+      working-directory: cerbero
+      env:
+        CI_PROJECT_NAME: cerbero
+      run: |
+        # Get GStreamer/cerbero version info and installer filenames
+        gstreamer_version=$(./cerbero-uninstalled packageinfo gstreamer-1.0 | awk '/Version:/ {print $2}')
+        echo "gstreamer-version=${gstreamer_version}" | tee -a $GITHUB_OUTPUT
+
+        cerbero_short_sha=$(git -C cerbero rev-parse --short HEAD)
+        echo "cerbero-short-sha=${cerbero_short_sha}" | tee -a $GITHUB_OUTPUT
+
+        echo "runtime-msi-filename=gstreamer-1.0-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
+        echo "dev-msi-filename=gstreamer-1.0-devel-msvc-x86_64-${gstreamer_version}-${cerbero_short_sha}.msi" | tee -a $GITHUB_OUTPUT
+
+    - id: check-installer-exists
+      if: ${{ inputs.force != 'true' && inputs.s3-download-paths }}
+      shell: msys2 -eo pipefail {0}
+      continue-on-error: true
+      env:
+        RUNTIME_MSI_FILENAME: ${{ steps.version-info.outputs.runtime-msi-filename }}
+        DEV_MSI_FILENAME: ${{ steps.version-info.outputs.dev-msi-filename }}
+        S3_DOWNLOAD_PATHS: ${{ inputs.s3-download-paths }}
+      run: |
+        # Check installer already exists in S3
+
+        runtime_msi="null"
+        dev_msi="null"
+
+        for download_path in ${S3_DOWNLOAD_PATHS}; do
+          echo "Checking for installers under ${download_path}"
+
+          bucket=$(echo ${download_path} | cut -d/ -f3)
+          prefix=$(echo ${download_path} | cut -d/ -f4-)
+
+          if [ "$runtime_msi" = "null" ]; then
+            echo "Checking for runtime installer under s3://${bucket}/${prefix}/"
+            runtime_msi=$(aws s3api list-objects-v2 --bucket "${bucket}" --prefix "${prefix}/" --query 'Contents[].Key' | jq -r 'if type!="array" then [] else . end | sort_by(length) | map(select(endswith("'"${RUNTIME_MSI_FILENAME}"'"))) | .[0]')
+            if [ "$runtime_msi" != "null" ]; then
+              echo "runtime-msi=s3://${bucket}/${runtime_msi}" | tee -a $GITHUB_OUTPUT
+            fi
+          fi
+
+          if [ "$dev_msi" = "null" ]; then
+            echo "Checking for development installer under s3://${bucket}/${prefix}/"
+            dev_msi=$(aws s3api list-objects-v2 --bucket "${bucket}" --prefix "${prefix}/" --query 'Contents[].Key' | jq -r 'if type!="array" then [] else . end | sort_by(length) | map(select(endswith("'"${DEV_MSI_FILENAME}"'"))) | .[0]')
+            if [ "$dev_msi" != "null" ]; then
+              echo "dev-msi=s3://${bucket}/${dev_msi}" | tee -a $GITHUB_OUTPUT
+            fi
+          fi
+
+          if [ "$runtime_msi" != "null" ] && [ "$dev_msi" != "null" ]; then
+            break
+          fi
+        done
+
+    - name: Set variables
+      id: variables
+      shell: msys2 -eo pipefail {0}
+      run: |
+        # Set variables for later steps
+        if [ -z "${{ steps.check-installer-exists.outputs.runtime-msi }}" ] ||
+          [ -z "${{ steps.check-installer-exists.outputs.dev-msi }}" ];
+        then
+          echo "do-build=true" >> $GITHUB_OUTPUT
+        fi
+
+    - if: ${{ steps.variables.outputs.do-build && inputs.bootstrap-system == 'true' }}
+      shell: msys2 -eo pipefail {0}
+      working-directory: cerbero
+      run: |
+        # Bootstrap Windows
+        powershell.exe ./tools/bootstrap-windows.ps1
+
+    - id: cerbero-config
+      if: ${{ steps.variables.outputs.do-build }}
+      working-directory: cerbero
+      shell: msys2 -eo pipefail {0}
+      env:
+        CERBERO_PATH: cerbero
+        CERBERO_HOME: cerbero-build
+        CERBERO_SOURCES: cerbero-sources
+        CERBERO: "./cerbero-uninstalled -c config/${{ inputs.config }} -c localconf.cbc"
+        CERBERO_ARGS: ${{ inputs.cerbero-args }}
+        CERBERO_PACKAGE_ARGS: ${{ inputs.cerbero-package-args }}
+      run: |
+        # Set up Cerbero configuration
+        echo "cerbero-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+        echo "cerbero-home=${CERBERO_PATH}\\${CERBERO_HOME}" >> $GITHUB_OUTPUT
+        echo "cerbero-sources=${CERBERO_PATH}\\${CERBERO_SOURCES}" >> $GITHUB_OUTPUT
+        echo "full-log-path=$(cygpath -au .)/${CERBERO_HOME}/logs" >> $GITHUB_OUTPUT
+
+        pwd_native=$(cygpath -am .)
+        echo "home_dir = \"${pwd_native}/${CERBERO_HOME}\"" > localconf.cbc
+        echo "local_sources = \"${pwd_native}/${CERBERO_SOURCES}\"" >> localconf.cbc
+        echo "vs_install_version = \"vs17\"" >> localconf.cbc
+        echo "num_of_cpus = ${NUMBER_OF_PROCESSORS}" >> localconf.cbc
+        cat localconf.cbc
+
+        git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"
+
+        echo "CERBERO=${CERBERO}" >> $GITHUB_ENV
+        echo "CERBERO_ARGS=${CERBERO_ARGS}" >> $GITHUB_ENV
+        echo "CERBERO_PACKAGE_ARGS=${CERBERO_PACKAGE_ARGS}" >> $GITHUB_ENV
+
+    - id: restore-cerbero-cache
+      if: ${{ steps.variables.outputs.do-build }}
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+          ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        key: |
+          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-${{ runner.name }}
+        restore-keys: |
+          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.cerbero-config.outputs.cerbero-sha }}-
+          ${{ runner.os }}-cerbero-bootstrap-${{ steps.version-info.outputs.gstreamer-version }}-
+          ${{ runner.os }}-cerbero-bootstrap-
+
+    - if: ${{ steps.variables.outputs.do-build && steps.restore-cerbero-cache.outputs.cache-matched-key }}
+      shell: msys2 -eo pipefail {0}
+      run: |
+        # Restore Cerbero dependencies
+        deps_file='${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz'
+
+        if [ ! -f "$deps_file" ]; then
+          exit 0
+        fi
+
+        echo "::group::Unpacking Cerbero Deps"
+        tar -xJf "${deps_file}" -C '${{ steps.cerbero-config.outputs.cerbero-home }}'
+        rm -f "${deps_file}"
+        ls -l '${{ steps.cerbero-config.outputs.cerbero-home }}'
+        echo "::endgroup::"
+
+    - id: bootstrap-cerbero
+      if: ${{ steps.variables.outputs.do-build }}
+      working-directory: cerbero
+      shell: msys2 -eo pipefail {0}
+      env:
+        CI_PROJECT_NAME: cerbero
+        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
+        FETCH_ARGS: --jobs=4
+      run: |
+        # Bootstrap Cerbero
+        mkdir -p "${LOG_PATH}"
+
+        group_cmd () {
+          echo "::group::$1"
+          eval $1
+          echo "::endgroup::"
+        }
+
+        group_cmd "pacman -Q" | tee "${LOG_PATH}/0_pacman.log"
+
+        # Build deps for all gstreamer recipes and any recipes that build gstreamer
+        # plugins (and hence compile against gstreamer)
+        build_deps="gstreamer-1.0 gst-plugins-base-1.0 gst-plugins-good-1.0
+            gst-plugins-bad-1.0 gst-plugins-ugly-1.0 gst-rtsp-server-1.0
+            gst-devtools-1.0 gst-editing-services-1.0 libnice gst-plugins-rs
+            gst-libav-1.0"
+        more_deps="glib-networking pkg-config"
+
+        group_cmd "$CERBERO $CERBERO_ARGS show-config" | tee "${LOG_PATH}/1_config.log"
+        group_cmd "$CERBERO $CERBERO_ARGS fetch-bootstrap $FETCH_ARGS" | tee "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS fetch-package $FETCH_ARGS --deps gstreamer-1.0" | tee -a "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS bootstrap --offline --system=no" | tee -a "${LOG_PATH}/2_bootstrap.log"
+        group_cmd "$CERBERO $CERBERO_ARGS build-deps --offline $build_deps" | tee "${LOG_PATH}/3_build-deps.log"
+        group_cmd "$CERBERO $CERBERO_ARGS build --offline $more_deps" | tee -a "${LOG_PATH}/3_build-deps.log"
+        group_cmd "$CERBERO $CERBERO_ARGS gen-cache" | tee "${LOG_PATH}/4_cache.log"
+
+    - id: cache-cerbero-bootstrap
+      if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-cache.outputs.cache-hit }}
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
+          ${{ steps.cerbero-config.outputs.cerbero-sources }}
+        key: ${{ steps.restore-cerbero-cache.outputs.cache-primary-key }}
+
+    - id: build-packages
+      if: ${{ steps.variables.outputs.do-build }}
+      working-directory: cerbero
+      shell: msys2 -eo pipefail {0}
+      env:
+        CI_PROJECT_NAME: cerbero
+        LOG_PATH: ${{ steps.cerbero-config.outputs.full-log-path }}
+      run: |
+        mkdir -p "${LOG_PATH}"
+        cmd="$CERBERO $CERBERO_ARGS package --offline ${CERBERO_PACKAGE_ARGS} -o \"$(cygpath -am .)\" gstreamer-1.0"
+        echo "::group::$cmd"
+        eval $cmd | tee "${LOG_PATH}/package.log"
+        echo "::endgroup::"
+
+        find ~+ -maxdepth 1 -name 'gstreamer-1.0-msvc*.msi' -exec sh -c 'echo runtime-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
+        find ~+ -maxdepth 1 -name 'gstreamer-1.0-devel*.msi' -exec sh -c 'echo dev-msi=$(cygpath -aw "{}") >> $GITHUB_OUTPUT' \;
+
+    - id: upload-packages
+      if: ${{ steps.build-packages.outcome == 'success' && inputs.s3-upload-path }}
+      shell: msys2 -eo pipefail {0}
+      working-directory: cerbero
+      run: |
+        echo "::group::Upload packages"
+
+        upload_path="${{ inputs.s3-upload-path }}/${{ steps.version-info.outputs.runtime-msi-filename }}"
+        aws s3 cp --no-progress "$(cygpath -u '${{ steps.build-packages.outputs.runtime-msi }}')" "${upload_path}"
+        echo "::notice title=GStreamer Runtime Installer Uploaded to S3::Location: ${upload_path}"
+        echo "runtime-msi=${upload_path}" | tee -a $GITHUB_OUTPUT
+
+        upload_path="${{ inputs.s3-upload-path }}/${{ steps.version-info.outputs.dev-msi-filename }}"
+        aws s3 cp --no-progress "$(cygpath -u '${{ steps.build-packages.outputs.dev-msi }}')" "${upload_path}"
+        echo "::notice title=GStreamer Development Installer Uploaded to S3::Location: ${upload_path}"
+        echo "dev-msi=${upload_path}" | tee -a $GITHUB_OUTPUT
+
+        echo "::endgroup::"
+
+    - id: presign-urls
+      if: ${{ (steps.check-installer-exists.outputs.runtime-msi && steps.check-installer-exists.outputs.dev-msi) || steps.upload-packages.outcome == 'success' }}
+      shell: bash
+      run: |
+        # Presign URLs for installers
+        echo "runtime-url=$(aws s3 presign '${{ steps.check-installer-exists.outputs.runtime-msi || steps.upload-packages.outputs.runtime-msi }}')" | tee -a $GITHUB_OUTPUT
+        echo "dev-url=$(aws s3 presign '${{ steps.check-installer-exists.outputs.dev-msi || steps.upload-packages.outputs.dev-msi }}')" | tee -a $GITHUB_OUTPUT
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ steps.build-packages.outputs.runtime-msi || steps.build-packages.outputs.dev-msi }}
+      with:
+        name: GStreamer Installers
+        path: |
+          ${{ steps.build-packages.outputs.runtime-msi }}
+          ${{ steps.build-packages.outputs.dev-msi }}
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v4
+      if: ${{ always() && steps.cerbero-config.outcome == 'success' }}
+      with:
+        name: cerbero-logs
+        path: ${{ steps.cerbero-config.outputs.cerbero-home }}\logs
+
+    - name: Cleanup Cerbero
+      if: ${{ always() && inputs.cleanup == 'true' && steps.get-cerbero.outcome != 'skipped' }}
+      shell: msys2 -eo pipefail {0}
+      run: rm -rf "cerbero"

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -280,13 +280,13 @@ runs:
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-sources }}
-        key: ${{ steps.restore-cerbero-deps-cache.cache-primary-key }}
+        key: ${{ steps.restore-cerbero-sources-cache.outputs.cache-primary-key }}
 
     - if: ${{ steps.bootstrap-cerbero.outcome == 'success' && ! steps.restore-cerbero-deps-cache.outputs.cache-hit }}
       uses: actions/cache/save@v4
       with:
         path: ${{ steps.cerbero-config.outputs.cerbero-home }}\cerbero-deps.tar.xz
-        key: ${{ steps.restore-cerbero-deps-cache.cache-primary-key }}
+        key: ${{ steps.restore-cerbero-deps-cache.outputs.cache-primary-key }}
 
     - id: build-packages
       if: ${{ steps.variables.outputs.do-build }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           cerbero-repo: ${{ inputs.cerbero-repo || github.repository }}
           cerbero-ref: ${{ inputs.cerbero-ref || github.ref }}
+          cerbero-args: --clocktime --timestamps -v visualstudio,noasserts,nochecks
           force: true
           bootstrap-system: true
           s3-download-paths: >-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,65 @@
+name: Windows
+
+on:
+  push:
+    branches: ['*.*.*-lldc']
+    tags: ['*.*.*-lldc*']
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      cerbero-repo:
+        description: 'Cerbero repository to use (defaults to the current repository)'
+        required: false
+      cerbero-ref:
+        description: 'Cerbero ref to use (defaults to the current ref)'
+        required: false
+      runner:
+        description: 'Runner labels to use'
+        required: false
+        type: choice
+        options:
+          - '["floor-to-ceiling-windows-latest-runner"]'
+          - '["self-hosted", "Windows", "X64", "cerbero"]'
+        default: '["self-hosted", "Windows", "X64", "cerbero"]'
+
+jobs:
+  build:
+    name: Build GStreamer Windows - ${{ (contains(inputs.runner, 'self-hosted') || inputs.runner == '') && 'Self-hosted' || 'GitHub-hosted' }}
+    runs-on: ${{ fromJSON(inputs.runner || '["self-hosted", "Windows", "X64", "cerbero"]') }}
+    steps:
+      - name: Get GStreamer installer S3 prefix
+        id: s3-prefix
+        if: vars.GSTREAMER_S3_UPLOAD_PREFIX
+        shell: bash
+        run: |
+          prefix="${{ vars.GSTREAMER_S3_UPLOAD_PREFIX }}/${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-${GITHUB_REF##*/}}}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            prefix="${prefix}-${{ github.run_number }}"
+          fi
+          echo "prefix=${prefix}" | tee -a $GITHUB_OUTPUT
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/actions/build-gstreamer-for-windows
+          sparse-checkout-cone-mode: false
+
+      - id: build-gstreamer
+        name: Build GStreamer
+        uses: ./.github/actions/build-gstreamer-for-windows
+        with:
+          cerbero-repo: ${{ inputs.cerbero-repo || github.repository }}
+          cerbero-ref: ${{ inputs.cerbero-ref || github.ref }}
+          force: true
+          bootstrap-system: true
+          s3-download-paths: >-
+            ${{ vars.GSTREAMER_S3_UPLOAD_BUCKET && vars.GSTREAMER_S3_UPLOAD_PREFIX && format('s3://{0}/{1}', vars.GSTREAMER_S3_UPLOAD_BUCKET, vars.GSTREAMER_S3_UPLOAD_PREFIX) || '' }}
+            ${{ vars.GSTREAMER_S3_UPLOAD_BUCKET && steps.s3-prefix.outcome != 'skipped' && format('s3://{0}/{1}', vars.GSTREAMER_S3_UPLOAD_BUCKET, steps.s3-prefix.outputs.prefix) || '' }}
+          s3-upload-path: >-
+            ${{ vars.GSTREAMER_S3_UPLOAD_BUCKET && vars.GSTREAMER_S3_UPLOAD_PREFIX && format('s3://{0}/{1}', vars.GSTREAMER_S3_UPLOAD_BUCKET, vars.GSTREAMER_S3_UPLOAD_PREFIX) || '' }}
+
+      - name: Annotate workflow run with GStreamer version
+        if: steps.build-gstreamer.outputs.gstreamer-version
+        run: |
+          echo "::notice title=Built GStreamer version ${{ steps.build-gstreamer.outputs.gstreamer-version }}::Created installer with Cerbero short sha ${{ steps.build-gstreamer.outputs.cerbero-short-sha }}"

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -106,7 +106,7 @@ class Variants(object):
         'rust',
         'qt6',
     ]
-    __enabled_variants = ['debug', 'optimization', 'testspackage']
+    __enabled_variants = ['debug', 'optimization', 'testspackage', 'asserts', 'checks']
     __bool_variants = __enabled_variants + __disabled_variants
     # Variants that are `key: (values)`, with the first value in the tuple
     # being the default

--- a/recipes/glib.recipe
+++ b/recipes/glib.recipe
@@ -256,6 +256,12 @@ class Recipe(recipe.Recipe):
             # https://github.com/mesonbuild/meson/issues/2121#issuecomment-347535874
             self.append_env('LDFLAGS', f'-Wl,-rpath,{self.config.libdir}')
 
+        if self.config.variants.noasserts:
+            self.meson_options.update({'glib_assert': 'false'})
+
+        if self.config.variants.nochecks:
+            self.meson_options.update({'glib_checks': 'false'})
+
     def post_install(self):
         if self.config.target_platform in [Platform.IOS, Platform.DARWIN]:
             # For the universal build we need to ship glibconfig.h of both

--- a/recipes/libnice.recipe
+++ b/recipes/libnice.recipe
@@ -16,7 +16,10 @@ class Recipe(recipe.Recipe):
                      'crypto-library' : 'openssl'}
     deps = ['glib', 'gstreamer-1.0']
 
-    patches = ['libnice/0001-Remove-Gslice-without-breaking-anything.patch']
+    patches = [
+        'libnice/0001-Remove-Gslice-without-breaking-anything.patch',
+        'libnice/0002-Add-glib-assert-and-check-options.patch',
+    ]
 
     files_bins = ['stunbdc', 'stund']
     files_libs = ['libnice']

--- a/recipes/libnice.recipe
+++ b/recipes/libnice.recipe
@@ -14,6 +14,7 @@ class Recipe(recipe.Recipe):
                      'gupnp' : 'disabled',
                      'gstreamer' : 'enabled',
                      'crypto-library' : 'openssl'}
+
     deps = ['glib', 'gstreamer-1.0']
 
     patches = [
@@ -40,6 +41,12 @@ class Recipe(recipe.Recipe):
         else:
             # openssl on Linux
             self.use_system_libs = True
+
+        if self.config.variants.noasserts:
+            self.meson_options.update({'glib-asserts': 'disabled'})
+
+        if self.config.variants.nochecks:
+            self.meson_options.update({'glib-checks': 'disabled'})
 
     def post_install (self):
         nice_deps = ['gio-2.0', 'gthread-2.0', 'ssl', 'crypto']

--- a/recipes/libnice.recipe
+++ b/recipes/libnice.recipe
@@ -13,8 +13,7 @@ class Recipe(recipe.Recipe):
     meson_options = {'tests' : 'disabled',
                      'gupnp' : 'disabled',
                      'gstreamer' : 'enabled',
-                     'crypto-library' : 'openssl',
-                     'c_args': '-DG_DISABLE_ASSERT'}
+                     'crypto-library' : 'openssl'}
     deps = ['glib', 'gstreamer-1.0']
 
     patches = ['libnice/0001-Remove-Gslice-without-breaking-anything.patch']

--- a/recipes/libnice/0002-Add-glib-assert-and-check-options.patch
+++ b/recipes/libnice/0002-Add-glib-assert-and-check-options.patch
@@ -1,0 +1,70 @@
+From a834638700e74fa72e362f0622c8283f62034e5f Mon Sep 17 00:00:00 2001
+From: Jeffery Wilson <jeff@jeffalwilson.com>
+Date: Thu, 27 Jun 2024 13:14:32 -0400
+Subject: [PATCH] Add glib assert and check options
+
+---
+ meson.build       | 12 ++++++++++++
+ meson_options.txt |  5 +++++
+ tests/meson.build |  7 ++++++-
+ 3 files changed, 23 insertions(+), 1 deletion(-)
+
+diff --git a/meson.build b/meson.build
+index badce49..3ae1177 100644
+--- a/meson.build
++++ b/meson.build
+@@ -85,6 +85,18 @@ add_project_arguments('-D_GNU_SOURCE',
+   '-DNICE_VERSION_NANO=' + version_nano,
+   language: 'c')
+ 
++glib_asserts = get_option('glib-asserts')
++if glib_asserts.disabled() or (glib_asserts.auto() and version_nano == '0')
++  message('Disabling GLib asserts')
++  add_project_arguments('-DG_DISABLE_ASSERT', language: 'c')
++endif
++
++glib_checks = get_option('glib-checks')
++if glib_checks.disabled() or (glib_checks.auto() and not gst_version_is_dev)
++  message('Disabling GLib checks')
++  add_project_arguments('-DG_DISABLE_CHECKS', language: 'c')
++endif
++
+ cdata = configuration_data()
+ 
+ cdata.set_quoted('PACKAGE_STRING', meson.project_name())
+diff --git a/meson_options.txt b/meson_options.txt
+index cd980cb..bd624c3 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -15,3 +15,8 @@ option('gtk_doc', type : 'feature', value : 'disabled', yield : true,
+   description: 'Generate API documentation with gtk-doc')
+ option('introspection', type : 'feature', value : 'auto', yield : true,
+   description : 'Generate gobject-introspection bindings')
++
++option('glib-asserts', type : 'feature', value : 'enabled', yield : true,
++       description: 'Enable GLib assertion (auto = enabled for development, disabled for stable releases)')
++option('glib-checks', type : 'feature', value : 'enabled', yield : true,
++       description: 'Enable GLib checks such as API guards (auto = enabled for development, disabled for stable releases)')
+diff --git a/tests/meson.build b/tests/meson.build
+index f149550..c66ffbd 100644
+--- a/tests/meson.build
++++ b/tests/meson.build
+@@ -76,9 +76,14 @@ if gst_dep.found() and not static_build
+   gst_check = dependency('gstreamer-check-1.0', required: get_option('gstreamer'),
+                          fallback : ['gstreamer', 'gst_check_dep'])
+   if gst_check.found()
++    test_defines = [
++      '-DG_LOG_DOMAIN="libnice-tests"',
++      '-UG_DISABLE_ASSERT',
++      '-UG_DISABLE_CAST_CHECKS',
++    ]
+     exe = executable('nice-test-gstreamer',
+       'test-gstreamer.c', extra_src,
+-      c_args: '-DG_LOG_DOMAIN="libnice-tests"',
++      c_args: test_defines,
+       include_directories: nice_incs,
+       dependencies: [nice_deps, gst_check, libm],
+       link_with: libnice,
+-- 
+2.45.2
+


### PR DESCRIPTION
Adds new `asserts` and `checks` variants. Both are enabled by default which does not change the existing behavior.

When run with `noasserts`:
- `glib` is configured with the meson option `-Dglib_assert=false`
- all meson projects are configured with the `-Db_ndebug=true` meson option
- all GStreamer projects are configured with the `-Dglib-asserts=disabled` meson option
- all Cargo recipes are configured with the `debug-assertions=false` config

When run with `nochecks`:
- `glib` is configured with the meson option `-Dglib_checks=false`
- all GStreamer projects are configured with the `-Dglib-checks=disabled` meson option
- all Cargo recipes are configured with the `overflow-checks=false` option

I also reverted #6 in favor of adding a patch to add the meson options `glib-asserts` and `glib-checks` to libnice, these options are set in the same way defined for GStreamer project defined above.

Workflows in this repo have now been added so no CN build is required. You can validate the flags are properly set by checking the Cerbero compile logs from the workflow run of this branch.