### PR TITLE
[VIDEO-2913] Add support for MetaPackage

### DIFF
--- a/cerbero/packages/packagesstore.py
+++ b/cerbero/packages/packagesstore.py
@@ -208,6 +208,8 @@ class PackagesStore(object):
             p = package_cls(self._config, self, self.cookbook)
         elif issubclass(package_cls, package.SDKPackage):
             p = package_cls(self._config, self)
+        elif issubclass(package_cls, package.MetaPackage):
+            p = package_cls(self._config, self)
         elif issubclass(package_cls, package.InstallerPackage):
             p = package_cls(self._config, self)
         elif issubclass(package_cls, package.Package):


### PR DESCRIPTION
Mirror of this fix: https://gitlab.freedesktop.org/gstreamer/cerbero/-/merge_requests/1519

Cerbero currently does not support its own MetaPackage -type as a build target even though it does actually work once you patch it.