### PR TITLE
[VIDEO-2870] Update version management

### DIFF
--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -180,6 +180,7 @@ runs:
         CERBERO: "./cerbero-uninstalled -c config/${{ inputs.config }} -c localconf.cbc"
         CERBERO_ARGS: ${{ inputs.cerbero-args }}
         CERBERO_PACKAGE_ARGS: ${{ inputs.cerbero-package-args }}
+        CERBERO_PACKAGE_ORIGIN: ${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.version-info.outputs.cerbero-short-sha }}
       run: |
         # Set up Cerbero configuration
         echo "cerbero-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -193,6 +194,7 @@ runs:
         echo "local_sources = \"${pwd_native}/${CERBERO_SOURCES}\"" >> localconf.cbc
         echo "vs_install_version = \"vs17\"" >> localconf.cbc
         echo "num_of_cpus = ${NUMBER_OF_PROCESSORS}" >> localconf.cbc
+        echo "package_origin = \"${CERBERO_PACKAGE_ORIGIN}\"" >> localconf.cbc
         cat localconf.cbc
 
         git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"

--- a/cerbero/config.py
+++ b/cerbero/config.py
@@ -289,6 +289,7 @@ class Config(object):
         'tomllib_path',
         'qt6_qmake_path',
         'system_build_tools',
+        'package_origin',
     ]
 
     cookbook = None
@@ -694,6 +695,7 @@ class Config(object):
         self.set_property('extra_mirrors', [])
         self.set_property('extra_bootstrap_packages', {})
         self.set_property('bash_completions', set())
+        self.set_property('package_origin', None)
         # Increase open-files limits
         set_nofile_ulimit()
 

--- a/recipes/gstreamer-1.0.recipe
+++ b/recipes/gstreamer-1.0.recipe
@@ -83,6 +83,10 @@ class Recipe(custom.GStreamer):
             self.meson_options['ptp-helper'] = 'enabled'
             self.files_misc.append('libexec/gstreamer-1.0/gst-ptp-helper%(bext)s')
 
+        # If package origin is specified, set it on the meson meson_options
+        if self.config.package_origin:
+            self.meson_options['package-origin'] = self.config.package_origin
+
     def post_install(self):
         if self.config.platform in (Platform.DARWIN, Platform.IOS):
             files = [


### PR DESCRIPTION
This update adds the following:

1. (Upstream-able) Change to the base config and gstreamer recipes to support a new configuration item, `package_origin`, that when set will result in setting the global macro `GST_PACKAGE_ORIGIN` to the provided string.
2. A change to the github action to populate `package_origin` in our `localconf.cbc` configuration file.