### PR TITLE
[VIDEO-3086] Configure gst-plugins-rs source, ref

### DIFF
--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -212,7 +212,7 @@ runs:
 
         # Switch gst-plugins-rs provider to blinemedical
         echo "recipes_remotes = {'gst-plugins-rs': {'patched': '${GST_PLUGINS_RS_SOURCE}'}}" >> localconf.cbc
-        echo "recipes_commits = {'gst-plugins-rs': 'patched/${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
+        echo "recipes_commits = {'gst-plugins-rs': '${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
         cat localconf.cbc
 
         git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -34,11 +34,9 @@ inputs:
   gst-plugins-rs-repo:
     description: 'Repository to use for gst-plugins-rs'
     required: false
-    default: 'https://github.com/blinemedical/gst-plugins-rs'
   gst-plugins-rs-ref:
     description: 'Ref/tag to use for gst-plugins-rs'
     required: false
-    default: '0.12.9-lldc.1'
   force:
     description: 'Whether to force the build'
     required: false
@@ -210,9 +208,11 @@ runs:
         echo "num_of_cpus = ${NUMBER_OF_PROCESSORS}" >> localconf.cbc
         echo "package_origin = \"${CERBERO_PACKAGE_ORIGIN}\"" >> localconf.cbc
 
-        # Switch gst-plugins-rs provider to blinemedical
-        echo "recipes_remotes = {'gst-plugins-rs': {'patched': '${GST_PLUGINS_RS_SOURCE}'}}" >> localconf.cbc
-        echo "recipes_commits = {'gst-plugins-rs': '${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
+        # Handle custom gst-plugins-rs provider
+        if [ -n "${GST_PLUGINS_RS_SOURCE}" ] && [ -n "${GST_PLUGINS_RS_REF}" ]; then
+          echo "recipes_remotes = {'gst-plugins-rs': {'patched': '${GST_PLUGINS_RS_SOURCE}'}}" >> localconf.cbc
+          echo "recipes_commits = {'gst-plugins-rs': '${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
+        fi
         cat localconf.cbc
 
         git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -221,7 +221,7 @@ runs:
         echo "CERBERO_ARGS=${CERBERO_ARGS}" >> $GITHUB_ENV
         echo "CERBERO_PACKAGE_ARGS=${CERBERO_PACKAGE_ARGS}" >> $GITHUB_ENV
 
-        config_hash=$(echo "${CERBERO_ARGS}${{ inputs.config }}" | sha256sum | cut -d' ' -f1)
+        config_hash=$(echo "${CERBERO_ARGS}${{ inputs.config }}${GST_PLUGINS_RS_SOURCE}${GST_PLUGINS_RS_REF}" | sha256sum | cut -d' ' -f1)
         echo "config-hash=${config_hash}" >> $GITHUB_OUTPUT
 
     - id: restore-cerbero-sources-cache

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -31,6 +31,14 @@ inputs:
   s3-upload-path:
     description: 'S3 path to upload to'
     required: false
+  gst-plugins-rs-repo:
+    description: 'Repository to use for gst-plugins-rs'
+    required: false
+    default: 'https://github.com/blinemedical/gst-plugins-rs'
+  gst-plugins-rs-ref:
+    description: 'Ref/tag to use for gst-plugins-rs'
+    required: false
+    default: '0.12-lldc'
   force:
     description: 'Whether to force the build'
     required: false
@@ -185,6 +193,8 @@ runs:
         CERBERO_ARGS: ${{ inputs.cerbero-args }}
         CERBERO_PACKAGE_ARGS: ${{ inputs.cerbero-package-args }}
         CERBERO_PACKAGE_ORIGIN: ${{ steps.version-info.outputs.gstreamer-version }}-${{ steps.version-info.outputs.cerbero-short-sha }}
+        GST_PLUGINS_RS_SOURCE: ${{ inputs.gst-plugins-rs-repo }}
+        GST_PLUGINS_RS_REF: ${{ inputs.gst-plugins-rs-ref }}
       run: |
         # Set up Cerbero configuration
         echo "cerbero-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
@@ -199,6 +209,10 @@ runs:
         echo "vs_install_version = \"vs17\"" >> localconf.cbc
         echo "num_of_cpus = ${NUMBER_OF_PROCESSORS}" >> localconf.cbc
         echo "package_origin = \"${CERBERO_PACKAGE_ORIGIN}\"" >> localconf.cbc
+
+        # Switch gst-plugins-rs provider to blinemedical
+        echo "recipes_remotes = {'gst-plugins-rs': {'patched': '${GST_PLUGINS_RS_SOURCE}'}}" >> localconf.cbc
+        echo "recipes_commits = {'gst-plugins-rs': 'patched/${GST_PLUGINS_RS_REF}'}" >> localconf.cbc
         cat localconf.cbc
 
         git clean -xdf -e localconf.cbc -e "${CERBERO_SOURCES}"

--- a/.github/actions/build-gstreamer-for-windows/action.yml
+++ b/.github/actions/build-gstreamer-for-windows/action.yml
@@ -38,7 +38,7 @@ inputs:
   gst-plugins-rs-ref:
     description: 'Ref/tag to use for gst-plugins-rs'
     required: false
-    default: '0.12-lldc'
+    default: '0.12.9-lldc.1'
   force:
     description: 'Whether to force the build'
     required: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,6 +62,8 @@ jobs:
           cerbero-repo: ${{ inputs.cerbero-repo || github.repository }}
           cerbero-ref: ${{ inputs.cerbero-ref || github.ref }}
           cerbero-args: --clocktime --timestamps -v visualstudio,noasserts,nochecks
+          gst-plugins-rs-repo: 'https://github.com/blinemedical/gst-plugins.rs'
+          gst-plugins-rs-ref: '0.12.9-lldc.1'
           force: ${{ inputs.force-build == true }}
           no-cache: ${{ inputs.no-cache == true }}
           bootstrap-system: true


### PR DESCRIPTION
Updated the github action to add `recipes_remotes` and `recipes_commits` into the configuration file, pointing `gst-plugins-rs` at our repository.  The target including the following two changes is `0.12.9-lldc.1`, [here](https://github.com/blinemedical/gst-plugins-rs/releases/tag/0.12.9-lldc.1).

1. blinemedical/gst-plugins-rs#2
2. blinemedical/gst-plugins-rs#5