### PR TITLE
Configure AWS credentials in case they're not set on the machine

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,13 @@ jobs:
           fi
           echo "prefix=${prefix}" | tee -a $GITHUB_OUTPUT
 
+      - name: Configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.DEV_AWS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DEV_AWS_KEY_SECRET }}
+          aws-region: 'us-east-1'
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `aws` CLI calls on the new runner failed due to lack of authorization credentials, this fixes that problem.