### PR TITLE
[WIP] 1.24-lldc Improve Setup/Install Behaviors

### DIFF
--- a/.github/actions/install-gstreamer/action.yml
+++ b/.github/actions/install-gstreamer/action.yml
@@ -113,6 +113,7 @@ runs:
         $GSTREAMER_BIN="$GSTREAMER_ROOT\bin"
         echo "$GSTREAMER_BIN" | Out-File -FilePath $Env:GITHUB_PATH -Append -Encoding utf8
         echo "PKG_CONFIG_PATH=$GSTREAMER_ROOT\lib\pkgconfig;$env:PKG_CONFIG_PATH" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8
+        echo "GSTREAMER_1_0_ROOT_MSVC_X86_64=$GSTREAMER_ROOT" | Out-File -FilePath $Env:GITHUB_ENV -Append -Encoding utf8
 
         echo "gstreamer-bin-dir=$GSTREAMER_BIN" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8
         echo "gstreamer-install-dir=$GSTREAMER_INSTALL_DIR" | Out-File -FilePath $Env:GITHUB_OUTPUT -Append -Encoding utf8

--- a/.github/actions/setup-gstreamer/action.yml
+++ b/.github/actions/setup-gstreamer/action.yml
@@ -55,6 +55,15 @@ outputs:
   cerbero-short-sha:
     description: 'Short SHA of the Cerbero checkout'
     value: ${{ steps.version-info.outputs.cerbero-short-sha }}
+  install-dir:
+    description: 'GStreamer install directory'
+    value: ${{ steps.install.outputs.install-dir }}
+  plugin-dir:
+    description: 'GStreamer plugin directory'
+    value: ${{ steps.install.outputs.plugin-dir }}
+  bin-dir:
+    description: 'GStreamer bin directory'
+    value: ${{ steps.install.outputs.bin-dir }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
On the setup action, we don't forward the install, plugin or bin directories as outputs which could make it hard for downstream projects to use this.

On the install action, we don't set the gstreamer environment variable pointing to the root of the installation. This might be the cause of downstream applications failing to find the root "automagically."